### PR TITLE
Add audio alerts with saved paths

### DIFF
--- a/src/components/CountdownClock.tsx
+++ b/src/components/CountdownClock.tsx
@@ -67,8 +67,17 @@ const CountdownClock = () => {
   const ntpManagerRef = useRef<NTPSyncManager | null>(null);
   const warningAudioRef = useRef<HTMLAudioElement | null>(null);
   const endAudioRef = useRef<HTMLAudioElement | null>(null);
-  
+
   const { addDebugLog, ...debugLogProps } = useDebugLog();
+
+  // Load saved audio paths from localStorage on first render
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const warn = localStorage.getItem('warningSoundPath');
+    const end = localStorage.getItem('endSoundPath');
+    if (warn) setWarningAudioPath(warn);
+    if (end) setEndAudioPath(end);
+  }, []);
 
   // Get local IP address for display
   useEffect(() => {
@@ -531,7 +540,12 @@ const CountdownClock = () => {
     } catch (error) {
       addDebugLog('UI', 'Failed to sync settings with server', { error: error.message });
     }
-    
+
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('warningSoundPath', warningAudioPath);
+      localStorage.setItem('endSoundPath', endAudioPath);
+    }
+
     setActiveTab('clock');
     toast({ title: "Settings Applied" });
   };

--- a/src/pages/ClockArena.tsx
+++ b/src/pages/ClockArena.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 interface ClockData {
   minutes: number;
@@ -27,6 +27,27 @@ const ClockArena = () => {
     betweenRoundsSeconds: 0,
     ntpOffset: 0
   });
+
+  const [warningSoundPath, setWarningSoundPath] = useState<string | null>(null);
+  const [endSoundPath, setEndSoundPath] = useState<string | null>(null);
+  const warningAudioRef = useRef<HTMLAudioElement | null>(null);
+  const endAudioRef = useRef<HTMLAudioElement | null>(null);
+
+  // Load audio paths from localStorage
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    setWarningSoundPath(localStorage.getItem('warningSoundPath'));
+    setEndSoundPath(localStorage.getItem('endSoundPath'));
+  }, []);
+
+  // Update audio refs when paths change
+  useEffect(() => {
+    warningAudioRef.current = warningSoundPath ? new Audio(warningSoundPath) : null;
+  }, [warningSoundPath]);
+
+  useEffect(() => {
+    endAudioRef.current = endSoundPath ? new Audio(endSoundPath) : null;
+  }, [endSoundPath]);
 
   useEffect(() => {
     // Connect to WebSocket for real-time updates
@@ -82,6 +103,31 @@ const ClockArena = () => {
   const getRoundColor = () => {
     return clockData.isRunning ? 'text-blue-400' : 'text-gray-400';
   };
+
+  const playAudio = async (ref: React.RefObject<HTMLAudioElement | null>) => {
+    if (!ref.current) return;
+    try {
+      await ref.current.play();
+    } catch {
+      // ignore playback errors
+    }
+  };
+
+  // Play audio at 10s warning and end
+  useEffect(() => {
+    if (
+      clockData.isRunning &&
+      !clockData.isPaused &&
+      !clockData.isBetweenRounds
+    ) {
+      if (clockData.minutes === 0 && clockData.seconds === 10 && warningAudioRef.current) {
+        playAudio(warningAudioRef);
+      }
+      if (clockData.minutes === 0 && clockData.seconds === 0 && endAudioRef.current) {
+        playAudio(endAudioRef);
+      }
+    }
+  }, [clockData.minutes, clockData.seconds, clockData.isRunning, clockData.isPaused, clockData.isBetweenRounds]);
 
   return (
     <div className="min-h-screen bg-black text-white">


### PR DESCRIPTION
## Summary
- store audio file paths in `localStorage` so they persist across pages
- play warning and end sounds on display pages

## Testing
- `npm test` *(fails: ts-jest cannot compile, WebSocket constructor issues)*

------
https://chatgpt.com/codex/tasks/task_e_686d7b51908c8330aa0820d82400d7e7