### PR TITLE
Add audio file upload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A touch-friendly countdown clock application. Originally built for Raspberry Pi,
 - **Debug Logging** – Built‑in log viewer with CSV export
 - **Network Time Sync** – Sync with an NTP server for accurate timing
 - **Responsive Design & Toasts** – Works on any screen with clear feedback
+- **Custom Audio Alerts** – Upload your own sounds for the 10‑second and final
+  countdown cues
 
 ## Installation & Setup
 
@@ -45,9 +47,12 @@ to use a different port.
 
 ### Touch Interface
 1. **Clock Tab**: Main countdown display with large timer and controls
-2. **Settings Tab**: Configure timer, rounds and between-rounds options
+2. **Settings Tab**: Configure timer, rounds, between-rounds options and upload
+   audio alert files
 3. **API Info Tab**: Copy-ready HTTP commands and docs
 4. **Debug Tab**: Inspect log entries and export CSV
+5. **Audio Uploads**: Load custom warning and final sounds directly in the
+   Settings tab
 
 ### Additional Displays
 - `GET /clockpretty` – Large dark mode display for broadcasting

--- a/src/components/SettingsTab.tsx
+++ b/src/components/SettingsTab.tsx
@@ -287,6 +287,20 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
                   onChange={(e) => setWarningSoundPath(e.target.value)}
                   className="bg-gray-700 border-gray-500 text-white rounded-xl"
                 />
+                <Input
+                  type="file"
+                  accept="audio/*"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) {
+                      const reader = new FileReader();
+                      reader.onload = () =>
+                        setWarningSoundPath(reader.result as string);
+                      reader.readAsDataURL(file);
+                    }
+                  }}
+                  className="bg-gray-700 border-gray-500 text-white rounded-xl p-2"
+                />
               </div>
               <div className="flex flex-col space-y-4">
                 <label className="block text-xl font-medium text-white">
@@ -297,6 +311,20 @@ const SettingsTab: React.FC<SettingsTabProps> = ({
                   value={endSoundPath}
                   onChange={(e) => setEndSoundPath(e.target.value)}
                   className="bg-gray-700 border-gray-500 text-white rounded-xl"
+                />
+                <Input
+                  type="file"
+                  accept="audio/*"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (file) {
+                      const reader = new FileReader();
+                      reader.onload = () =>
+                        setEndSoundPath(reader.result as string);
+                      reader.readAsDataURL(file);
+                    }
+                  }}
+                  className="bg-gray-700 border-gray-500 text-white rounded-xl p-2"
                 />
               </div>
             </CardContent>


### PR DESCRIPTION
## Summary
- allow uploading audio files for timer alerts in Settings tab
- document new feature in README

## Testing
- `npm test` *(fails: Module not found/TypeErrors)*

------
https://chatgpt.com/codex/tasks/task_e_686d7d5671dc83308fdb055eb41b9a74