### PR TITLE
Sync settings from /api/status

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ curl -X POST http://localhost:4040/api/set-between-rounds \
 curl http://localhost:4040/api/status
 ```
 
+The web interface fetches this endpoint when it loads to populate the Settings
+tab with the current configuration from the server.
+
 The application also exposes a lightweight endpoint for integrations:
 
 ```bash


### PR DESCRIPTION
## Summary
- load initial timer settings from `/api/status`
- avoid overwriting server settings when a WebSocket connects
- document that settings load from `/api/status`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef184a4e88330a8c5cc270ca70990